### PR TITLE
Use www subdomain in arduino.cc URLs

### DIFF
--- a/libraries/USBHost/examples/KeyboardController/KeyboardController.ino
+++ b/libraries/USBHost/examples/KeyboardController/KeyboardController.ino
@@ -7,7 +7,7 @@
  created 8 Oct 2012
  by Cristian Maglie
 
- http://arduino.cc/en/Tutorial/KeyboardController
+ https://www.arduino.cc/en/Tutorial/KeyboardController
 
  This sample code is part of the public domain.
  */

--- a/libraries/USBHost/examples/MouseController/MouseController.ino
+++ b/libraries/USBHost/examples/MouseController/MouseController.ino
@@ -7,7 +7,7 @@
  created 8 Oct 2012
  by Cristian Maglie
 
- http://arduino.cc/en/Tutorial/MouseController
+ https://www.arduino.cc/en/Tutorial/MouseController
 
  This sample code is part of the public domain.
  */

--- a/libraries/USBHost/library.properties
+++ b/libraries/USBHost/library.properties
@@ -5,5 +5,5 @@ maintainer=Arduino <info@arduino.cc>
 sentence=Allows the communication with USB peripherals like mice, keyboards, and thumbdrives. For Arduino MKR1000 and Zero.
 paragraph=The USBHost library allows the board to appear as a USB host, enabling it to communicate with peripherals like USB mice and keyboards. USBHost does not support devices that are connected through USB hubs. This includes some keyboards that have an internal hub.
 category=Other
-url=http://arduino.cc/en/Reference/USBHost
+url=https://www.arduino.cc/en/Reference/USBHost
 architectures=samd


### PR DESCRIPTION
www.arduino.cc is Arduino's preferred url.